### PR TITLE
Check for _KeyCodeConnection before disconnect

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -658,7 +658,9 @@ function TopBarIconObject:SetImageSize(imageSize: Vector2)
 end
 
 function TopBarIconObject:Destroy()
-	self._KeyCodeConnection:Disconnect()
+	if self._KeyCodeConnection then
+		self._KeyCodeConnection:Disconnect()
+	end
 
 	if self._NoticeConnection then
 		self._NoticeConnection:Disconnect()

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canary-development/uishelf"
-version = "1.1.1"
+version = "1.1.2"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"


### PR DESCRIPTION
Currently, destroying a TopBarIconObject doesn't correctly check if _KeyCodeConnection exists before disconnecting it. This PR fixes that.