### PR TITLE
Fix TooltipLayer resetting on spawn

### DIFF
--- a/src/UIElements/TooltipLayer.luau
+++ b/src/UIElements/TooltipLayer.luau
@@ -4,5 +4,6 @@ TooltipLayer.DisplayOrder = 1e+09
 TooltipLayer.IgnoreGuiInset = true
 TooltipLayer.ScreenInsets = Enum.ScreenInsets.DeviceSafeInsets
 TooltipLayer.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+TooltipLayer.ResetOnSpawn = false
 
 return TooltipLayer


### PR DESCRIPTION
Lots of funky errors relating to tweening when hovering over a button with a tooltip when a player resets. Narrowed it down to something as simple as this.