### PR TITLE
Add description to Wally

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,5 +1,6 @@
 [package]
 name = "canary-development/uishelf"
+description = "Create modern & intuitive topbar icons."
 version = "1.1.5"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
Adds a description in the `wally.toml` based off of the one used for GitHub.